### PR TITLE
chore: Less strict PR title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -49,7 +49,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           # Related to `validateSingleCommit` you can opt-in to validate that the PR
           # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: true
+          validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- removed policy that checks first commit on PRs

### Motivation and context

Now GitHub support the option for Squash and Merge to use PR title as default commit message.
In this repo is now enabled to use PR title as default commit message, so now we can disable the policy.

<img width="721" alt="Screenshot 2022-08-02 at 08 28 07" src="https://user-images.githubusercontent.com/59291437/182306835-3f30f8a8-ea00-4075-93fa-2b8b3d3a490b.png">

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
